### PR TITLE
fix: update pom to fix distributionManagement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <scm>
         <url>https://github.com/jcasbin/shiro-casbin</url>
         <connection>scm:git@github.com:jcasbin/shiro-casbin.git</connection>
-        <developerConnection>scm:git:https://github.com/jcasbin/shiro-casbin. git</developerConnection>
+        <developerConnection>scm:git:https://github.com/jcasbin/shiro-casbin.git</developerConnection>
     </scm>
     <developers>
         <developer>
@@ -55,6 +55,18 @@
         <spring-boot.version>2.3.4.RELEASE</spring-boot.version>
         <spring.version>5.2.9.RELEASE</spring.version>
     </properties>
+
+
+    <distributionManagement>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+        <repository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+    </distributionManagement>
 
     <build>
         <plugins>
@@ -108,7 +120,7 @@
                         <format>html</format>
                         <format>xml</format>
                     </formats>
-                    <check />
+                    <check/>
                 </configuration>
             </plugin>
             <plugin>
@@ -129,72 +141,59 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>1.5</version>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <!-- We sign in the verify phase, which means it will happen before install and deploy (the last two phases)
+                             but not before earlier phases like test or package. -->
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>sign</goal>
+                        </goals>
+                        <!-- If using gpg > 2.1 it is necessary for gpg to not try to use the pinentry programs
+                          however, it looks like Travis does not need this entry -->
+                    </execution>
+                </executions>
+                <configuration>
+                    <!-- Prevent gpg from using pinentry programs -->
+                    <gpgArguments>
+                        <arg>--pinentry-mode</arg>
+                        <arg>loopback</arg>
+                    </gpgArguments>
+                </configuration>
+            </plugin>
+            <plugin>
+                <!-- Include zipped source code in releases -->
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <!-- Automatically close and deploy from OSSRH -->
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <version>1.6.7</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <serverId>ossrh</serverId>
+                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                    <!-- Release versions will be synced to Maven Central automatically. -->
+                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
-
-    <profiles>
-        <profile>
-            <id>release</id>
-            <distributionManagement>
-                <snapshotRepository>
-                    <id>ossrh</id>
-                    <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-                </snapshotRepository>
-                <repository>
-                    <id>ossrh</id>
-                    <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-                </repository>
-            </distributionManagement>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.5</version>
-                        <executions>
-                            <execution>
-                                <id>sign-artifacts</id>
-                                <!-- We sign in the verify phase, which means it will happen before install and deploy (the last two phases)
-                                     but not before earlier phases like test or package. -->
-                                <phase>verify</phase>
-                                <goals>
-                                    <goal>sign</goal>
-                                </goals>
-                                <!-- If using gpg > 2.1 it is necessary for gpg to not try to use the pinentry programs
-                                  however, it looks like Travis does not need this entry -->
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <!-- Include zipped source code in releases -->
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-source-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>attach-sources</id>
-                                <goals>
-                                    <goal>jar-no-fork</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <!-- Automatically close and deploy from OSSRH -->
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.7</version>
-                        <extensions>true</extensions>
-                        <configuration>
-                            <serverId>ossrh</serverId>
-                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                            <!-- Release versions will be synced to Maven Central automatically. -->
-                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
Fix: https://github.com/jcasbin/shiro-casbin/issues/30

I have try it in my [repo](https://github.com/imp2002/maven-release-example), and it's success.

401 error in shiro-casbin, that's because there is no permission, two errors cause `401`.

One is that the account of `ossrh` does not have permission.

And the other is that the id of `<distributionManagement>` is not set correctly, and I found it's in profile `release`, the `release` environment doesn't seem to be used by default. So I try use multiple profiles and putting `distributionManagement` under the `release` profile in my repo as same as `shiro-casbin`, **the same error as shiro-casbin appeared** (https://github.com/imp2002/maven-release-example/commit/54f9c09fdd63e577a0ef30a7948ce2ba206b2b8b).

And move it out to default environment solve it(https://github.com/imp2002/maven-release-example/commit/f35c9412c67a016a86c6214eed87b5e575bed56e).



